### PR TITLE
Added option to use custom file naming policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,9 +272,24 @@ builder.Services.AddWebAssemblyJsonLocalization(
         }));
 ```
 
-> Note that naming your static asset file, you can change the separator between the resource name
-> and the culture with `CultureSeparator`. So instead of naming your file `MyComponent-fr.json` you can name
-> it with a dot like this `MyComponent.fr.json` by setting the option CultureSeparator to `'.'`.
+> Note that naming your static asset file, you can change the expected file name by using
+> the `NamingPolicy` delegate. So instead of naming your file `MyComponent-fr.json` you can customize it
+> it by setting the `NamingPolicy` option to something like:
+> ```csharp
+> // Here we are going to change the culture separator to a dot `.` instead of a `-` and add a version querystring to help with cache busting
+> // having `MyComponent.fr.json?v=1.0.0.1` as a result
+> builder.Services.AddWebAssemblyJsonLocalization(
+>     builder => builder.UseHttpHostedJson(
+>         options =>
+>         {
+>             options.ApplicationAssembly = typeof(Program).Assembly;
+>             options.ResourcesPath = "Resources";
+>             options.NamingPolicy =  
+>                 (basePath, cultureName) => string.IsNullOrEmpty(cultureName)
+>                     ? new Uri($"{basePath}.json?v=1.0.0.1", UriKind.Relative)
+>                     : new Uri($"{basePath}.{cultureName}.json?v=1.0.0.1", UriKind.Relative);
+>         }));
+> ```
 
 #### Dependency injection in Blazor Server Side
 

--- a/README.md
+++ b/README.md
@@ -31,23 +31,23 @@ You can checkout this Github repository or you can use the NuGet packages:
 
 **Install using the command line from the Package Manager:**
 ```bash
-Install-Package SoloX.BlazorJsonLocalization -version 1.0.3-alpha.2
-Install-Package SoloX.BlazorJsonLocalization.WebAssembly -version 1.0.3-alpha.2
-Install-Package SoloX.BlazorJsonLocalization.ServerSide -version 1.0.3-alpha.2
+Install-Package SoloX.BlazorJsonLocalization -version 1.0.3-alpha.3
+Install-Package SoloX.BlazorJsonLocalization.WebAssembly -version 1.0.3-alpha.3
+Install-Package SoloX.BlazorJsonLocalization.ServerSide -version 1.0.3-alpha.3
 ```
 
 **Install using the .Net CLI:**
 ```bash
-dotnet add package SoloX.BlazorJsonLocalization --version 1.0.3-alpha.2
-dotnet add package SoloX.BlazorJsonLocalization.WebAssembly --version 1.0.3-alpha.2
-dotnet add package SoloX.BlazorJsonLocalization.ServerSide --version 1.0.3-alpha.2
+dotnet add package SoloX.BlazorJsonLocalization --version 1.0.3-alpha.3
+dotnet add package SoloX.BlazorJsonLocalization.WebAssembly --version 1.0.3-alpha.3
+dotnet add package SoloX.BlazorJsonLocalization.ServerSide --version 1.0.3-alpha.3
 ```
 
 **Install editing your project file (csproj):**
 ```xml
-<PackageReference Include="SoloX.BlazorJsonLocalization" Version="1.0.3-alpha.2" />
-<PackageReference Include="SoloX.BlazorJsonLocalization.WebAssembly" Version="1.0.3-alpha.2" />
-<PackageReference Include="SoloX.BlazorJsonLocalization.ServerSide" Version="1.0.3-alpha.2" />
+<PackageReference Include="SoloX.BlazorJsonLocalization" Version="1.0.3-alpha.3" />
+<PackageReference Include="SoloX.BlazorJsonLocalization.WebAssembly" Version="1.0.3-alpha.3" />
+<PackageReference Include="SoloX.BlazorJsonLocalization.ServerSide" Version="1.0.3-alpha.3" />
 ```
 
 ## How to use it

--- a/README.md
+++ b/README.md
@@ -274,10 +274,10 @@ builder.Services.AddWebAssemblyJsonLocalization(
 
 > Note that naming your static asset file, you can change the expected file name by using
 > the `NamingPolicy` delegate. So instead of naming your file `MyComponent-fr.json` you can customize it
-> it by setting the `NamingPolicy` option to something like:
+> like this `MyComponent.fr.json?v=1.0.0.1` it by setting the `NamingPolicy` delegate to something like:
 > ```csharp
-> // Here we are going to change the culture separator to a dot `.` instead of a `-` and add a version querystring to help with cache busting
-> // having `MyComponent.fr.json?v=1.0.0.1` as a result
+> // Here we are going to change the culture separator to a dot `.` instead of a `-` 
+> // and add a version querystring to help with cache busting
 > builder.Services.AddWebAssemblyJsonLocalization(
 >     builder => builder.UseHttpHostedJson(
 >         options =>

--- a/src/SharedProperties.props
+++ b/src/SharedProperties.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>1.0.3-alpha.2</Version>
+    <Version>1.0.3-alpha.3</Version>
     <Authors>Xavier Solau</Authors>
     <Copyright>Copyright © 2021 Xavier Solau</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/libs/SoloX.BlazorJsonLocalization/HttpHostedJsonLocalizationOptions.cs
+++ b/src/libs/SoloX.BlazorJsonLocalization/HttpHostedJsonLocalizationOptions.cs
@@ -23,7 +23,7 @@ namespace SoloX.BlazorJsonLocalization
         public string ResourcesPath { get; set; } = string.Empty;
 
         /// <summary>
-        /// Naming policy
+        /// Set the delegate for custom file naming
         /// </summary>
         public Func<string, string, Uri> NamingPolicy { get; set; } =
             (basePath, cultureName) => string.IsNullOrEmpty(cultureName)

--- a/src/libs/SoloX.BlazorJsonLocalization/HttpHostedJsonLocalizationOptions.cs
+++ b/src/libs/SoloX.BlazorJsonLocalization/HttpHostedJsonLocalizationOptions.cs
@@ -7,6 +7,7 @@
 // ----------------------------------------------------------------------
 
 using SoloX.BlazorJsonLocalization.Core;
+using System;
 using System.Reflection;
 
 namespace SoloX.BlazorJsonLocalization
@@ -22,9 +23,12 @@ namespace SoloX.BlazorJsonLocalization
         public string ResourcesPath { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets/Sets the separator for the culture. Defaults to '-'
+        /// Naming policy
         /// </summary>
-        public string CultureSeparator { get; set; } = "-";
+        public Func<string, string, Uri> NamingPolicy { get; set; } =
+            (basePath, cultureName) => string.IsNullOrEmpty(cultureName)
+             ? new Uri($"{basePath}.json", UriKind.Relative)
+             : new Uri($"{basePath}-{cultureName}.json", UriKind.Relative);
 
         /// <summary>
         /// Adds a querystring version to the resource path. Use it for cache busting

--- a/src/libs/SoloX.BlazorJsonLocalization/HttpHostedJsonLocalizationOptions.cs
+++ b/src/libs/SoloX.BlazorJsonLocalization/HttpHostedJsonLocalizationOptions.cs
@@ -27,6 +27,11 @@ namespace SoloX.BlazorJsonLocalization
         public string CultureSeparator { get; set; } = "-";
 
         /// <summary>
+        /// Adds a querystring version to the resource path. Use it for cache busting
+        /// </summary>
+        public string Version { get; set; } = string.Empty;
+
+        /// <summary>
         /// Gets/Sets the application assembly.
         /// </summary>
         public Assembly? ApplicationAssembly { get; set; }

--- a/src/libs/SoloX.BlazorJsonLocalization/Services/Impl/AHttpHostedJsonLocalizationExtensionService.cs
+++ b/src/libs/SoloX.BlazorJsonLocalization/Services/Impl/AHttpHostedJsonLocalizationExtensionService.cs
@@ -71,9 +71,10 @@ namespace SoloX.BlazorJsonLocalization.Services.Impl
             return await CultureInfoHelper.WalkThoughCultureInfoParentsAsync(cultureInfo,
                 cultureName =>
                 {
+                    var versionSuffix = !string.IsNullOrWhiteSpace(options.Version) ? $"?v={options.Version}" : string.Empty;
                     var uri = string.IsNullOrEmpty(cultureName)
-                    ? new Uri($"{basePath}.json", UriKind.Relative)
-                    : new Uri($"{basePath}{options.CultureSeparator}{cultureName}.json", UriKind.Relative);
+                    ? new Uri($"{basePath}.json{versionSuffix}", UriKind.Relative)
+                    : new Uri($"{basePath}{options.CultureSeparator}{cultureName}.json{versionSuffix}", UriKind.Relative);
 
                     this.logger.LogDebug($"Loading static assets data from {uri}");
 

--- a/src/libs/SoloX.BlazorJsonLocalization/Services/Impl/AHttpHostedJsonLocalizationExtensionService.cs
+++ b/src/libs/SoloX.BlazorJsonLocalization/Services/Impl/AHttpHostedJsonLocalizationExtensionService.cs
@@ -71,10 +71,7 @@ namespace SoloX.BlazorJsonLocalization.Services.Impl
             return await CultureInfoHelper.WalkThoughCultureInfoParentsAsync(cultureInfo,
                 cultureName =>
                 {
-                    var versionSuffix = !string.IsNullOrWhiteSpace(options.Version) ? $"?v={options.Version}" : string.Empty;
-                    var uri = string.IsNullOrEmpty(cultureName)
-                    ? new Uri($"{basePath}.json{versionSuffix}", UriKind.Relative)
-                    : new Uri($"{basePath}{options.CultureSeparator}{cultureName}.json{versionSuffix}", UriKind.Relative);
+                    var uri = options.NamingPolicy.Invoke(basePath, cultureName);
 
                     this.logger.LogDebug($"Loading static assets data from {uri}");
 


### PR DESCRIPTION
Since the resources are loaded asynchronously, it was a bit harder to update the resources when updating to a new version of the app. I added the option to add a version suffix to the JSON file requests to help with cache busting